### PR TITLE
feat(infra): add cron job to keep database alive

### DIFF
--- a/api/keep-alive.js
+++ b/api/keep-alive.js
@@ -1,0 +1,15 @@
+import { getSupabaseAdmin } from './_lib/supabase.js';
+
+export default async function handler(req, res) {
+  try {
+    const supabase = getSupabaseAdmin();
+    await supabase.from('services').select('id').limit(1);
+    res.status(200).json({ ok: true });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+}
+
+export const config = {
+  schedule: '0 0 * * *'
+};


### PR DESCRIPTION
Prevents Supabase free tier auto-pause by pinging the database
daily. Runs automatically on Vercel via schedule export.