### PR TITLE
fix(lint): resolve ESLint errors and React hooks warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,4 +27,18 @@ export default defineConfig([
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     },
   },
+  {
+    files: ['api/**/*.{js,jsx}', 'vite.config.js'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.node,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    rules: {
+      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+    },
+  },
 ])

--- a/src/components/AddServiceForm/AddServiceForm.jsx
+++ b/src/components/AddServiceForm/AddServiceForm.jsx
@@ -136,8 +136,7 @@ export function AddServiceForm() {
     const [query, setQuery] = useState("");
     const [images, setImages] = useState([]);
     const optionsRef = useRef(null);
-    const imagesRef = useRef(images);
-    imagesRef.current = images;
+    const imagesRef = useRef([]);
     const wasSubmittedRef = useRef(false);
     const removedIdsRef = useRef(new Set());
     const pageUnloadingRef = useRef(false);
@@ -149,6 +148,10 @@ export function AddServiceForm() {
     const dragCountRef = useRef(0);
     const [draggingId, setDraggingId] = useState(null);
     const [dragOverId, setDragOverId] = useState(null);
+
+    useEffect(() => {
+        imagesRef.current = images;
+    }, [images]);
 
     useEffect(() => {
         isUnmountingRef.current = false;

--- a/src/pages/admin/AdminQueuePage.jsx
+++ b/src/pages/admin/AdminQueuePage.jsx
@@ -6,18 +6,20 @@ export function AdminQueuePage() {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
 
-  const fetchPending = async () => {
-    const { data, error } = await supabase
-      .from('services')
-      .select('*')
-      .eq('approved', false)
-      .order('submitted_at', { ascending: false });
+  useEffect(() => {
+    const fetchPending = async () => {
+      const { data, error } = await supabase
+        .from('services')
+        .select('*')
+        .eq('approved', false)
+        .order('submitted_at', { ascending: false });
 
-    if (!error) setItems(data || []);
-    setLoading(false);
-  };
+      if (!error) setItems(data || []);
+      setLoading(false);
+    };
 
-  useEffect(() => { fetchPending(); }, []);
+    fetchPending();
+  }, []);
 
   const approve = async (id) => {
     const { error } = await supabase.from('services').update({ approved: true }).eq('id', id);

--- a/src/pages/admin/AdminServicesPage.jsx
+++ b/src/pages/admin/AdminServicesPage.jsx
@@ -299,17 +299,19 @@ export function AdminServicesPage() {
   const [statusFilter, setStatusFilter] = useState('all');
   const [selected, setSelected] = useState(null);
 
-  const fetchAll = async () => {
-    const { data, error } = await supabase
-      .from('services')
-      .select('*')
-      .order('submitted_at', { ascending: false });
+  useEffect(() => {
+    const fetchAll = async () => {
+      const { data, error } = await supabase
+        .from('services')
+        .select('*')
+        .order('submitted_at', { ascending: false });
 
-    if (!error) setServices(data || []);
-    setLoading(false);
-  };
+      if (!error) setServices(data || []);
+      setLoading(false);
+    };
 
-  useEffect(() => { fetchAll(); }, []);
+    fetchAll();
+  }, []);
 
   const handleSave = (updated) => {
     if (updated === null) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,3 @@
-/* global process */
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'


### PR DESCRIPTION
Add Node.js globals config for api/** and vite.config.js. Move async fetch functions inside useEffect to prevent setState warnings in AdminQueuePage and AdminServicesPage. Sync imagesRef through useEffect in AddServiceForm instead of during render.